### PR TITLE
Inverted Controls CheckBox is editable

### DIFF
--- a/Controller/SaveFileController.java
+++ b/Controller/SaveFileController.java
@@ -496,6 +496,7 @@ public class SaveFileController implements ViewListener {
 			break;
 		case nonInvertedYAxis: case nonInvertedXAxis: // need to inverse these fields to have the 'Inverted' checkbox
 			modelVal = !((Boolean.parseBoolean(viewVal)))+"";
+			break;
 		case foregroundWeather:
 			modelVal = foregroundWeatherValues.get(viewVal);
 			break;


### PR DESCRIPTION
When translating the inverted controls CheckBox from view to model value (in viewToModel()), the intended model value is overwritten because of a missing break. So the returned model value is invalid, which causes these checkboxes to revert to their previous value/are unchanged.

Fixes #30 