### PR TITLE
Fixed money SaveField bug

### DIFF
--- a/Model/SaveFile.java
+++ b/Model/SaveFile.java
@@ -119,7 +119,7 @@ public class SaveFile {
 		put(SaveField.cameraDistance, new Data(0x11F3C, 0x11F40, DataType.Float));
 
 		// ITEM
-		put(SaveField.money, new Data(0x2404A, 0x2404C, DataType.Int));
+		put(SaveField.money, new Data(0x24048, 0x2404C, DataType.Int));
 
 		// WTHR
 		put(SaveField.weatherReroll, new Data(0x24090, 0x24094, DataType.Float));


### PR DESCRIPTION
The money SaveField would only be saved into 2 bytes, even though the SaveField has type of 4 byte int. This would cause this field to reload to a different value if a value greater than the 2 byte int max was input. Fixed by having the money SaveField be 4 bytes.